### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Parameters
 Methods
 -------
 
-###recheck()
+### recheck()
 Ask responsImg to check the width again and trigger a `src` change if necessary
 
     $('.responsive-image').data('responsImg').recheck()


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
